### PR TITLE
Feat/GitHub pull ready

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -2,6 +2,14 @@
 
 This document defines how the Opencode automation agents should operate, how progress is tracked across sessions, and how to resume work after interruptions. It also provides a minimal state model and example workflows to ensure continuity when starting fresh or picking up where you left off.
 
+## Note on GitHub-sourced startup script
+- The host startup.bat now fetches select_apps.ps1, install_apps.ps1, and apps.json from a public GitHub repository before running. This keeps scripts up-to-date but means the host must rely on the remote repo for the exact versions used during execution.
+- Do not manually modify startup.bat on the host. If updates are needed, make changes in the GitHub repository and re-run or re-pull on the host to apply.
+
+## Repo URL
+- Public repo: https://github.com/cods4/windows_sandbox
+- Raw files are pulled from https://raw.githubusercontent.com/cods4/windows_sandbox/main/
+
 ## Goals
 - Allow Opencode to be started fresh and #pick up where it left off by persisting a lightweight state.
 - Provide a deterministic, observable workflow for multi-step tasks.
@@ -11,7 +19,7 @@ This document defines how the Opencode automation agents should operate, how pro
 - State file path (root of project): .\agents_state.json
 - If a deeper project structure is desired, you can switch to a dedicated directory (eg. .\state\agents_state.json). The examples below assume root-level state for simplicity.
 
-Note: If you already have a memory file (.github/instructions/memory.instruction.md) describing the intended goals, you can reference it to seed initial steps.
+Note: If you already have a memory file (.github/instructions/memory.instruction.md), use that as guidance to seed initial steps when there is no existing state.
 
 ## State schema (JSON)
 A minimal, future-proof model. This is designed to be simple to read/write and upgrade in place.

--- a/install_apps.ps1
+++ b/install_apps.ps1
@@ -68,13 +68,13 @@ if ($LASTEXITCODE -ne 0) {
         exit 1
     }
     winget --version | Out-Null
-+    if ($LASTEXITCODE -ne 0) {
-+        Write-Log "[FATAL ERROR] Winget installation verification failed."
-+        exit 1
-+    }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Log "[FATAL ERROR] Winget installation verification failed."
+        exit 1
+    }
 } else {
     Write-Log "[INFO] Winget is already installed."
-+}
+}
 
 # =============================================================================
 # --- 2. BEGIN APPLICATION INSTALLATIONS VIA IMPORT ---

--- a/select_apps.ps1
+++ b/select_apps.ps1
@@ -1,4 +1,4 @@
-<#!
+<#
 .SYNOPSIS
     A PowerShell-based GUI that lets you select which applications from apps.json to install
     in Windows Sandbox. The selected subset is written to apps_selected.json.
@@ -100,7 +100,18 @@ $okBtn.Add_Click({
     $newJson['Sources'] += $srcObj
     $newJson['WinGetVersion'] = $winGetVersion
 
-    $outPath = 'C:\startupscripts\apps_selected.json'
+    $outDir = 'C:\startupscripts'
+    if (-Not (Test-Path -Path $outDir)) {
+        try {
+            New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+        } catch {
+            [System.Windows.Forms.MessageBox]::Show("Cannot create $outDir to write apps_selected.json. Exiting.", 'Error',[System.Windows.Forms.MessageBoxButtons]::OK,[System.Windows.Forms.MessageBoxIcon]::Error)
+            $form.Close()
+            exit 1
+        }
+    }
+
+    $outPath = Join-Path $outDir 'apps_selected.json'
     $newJson | ConvertTo-Json -Depth 99 | Out-File -FilePath $outPath -Encoding UTF8
 
     Write-Host "Selected apps written to $outPath"
@@ -117,3 +128,4 @@ $form.Controls.Add($cancelBtn)
 $form.Add_Shown({ $form.Activate() })
 $form.ShowDialog() | Out-Null
 
+</file>

--- a/startup.bat
+++ b/startup.bat
@@ -13,18 +13,65 @@ echo. >> "%LOG_FILE%"
 echo ================================================================= >> "%LOG_FILE%"
 echo. >> "%LOG_FILE%"
 
+:: Pull latest scripts from GitHub (basic, logging only)
+:: Use the public raw base of the actual repository
+set "GITHUB_RAW_BASE=https://raw.githubusercontent.com/cods4/windows_sandbox/main"
+set "SCRIPTS_DIR=C:\startupscripts"
+if not exist "%SCRIPTS_DIR%" mkdir "%SCRIPTS_DIR%"
+
+set "DOWNLOAD_FAILED=0"
+
+echo Pulling latest scripts from GitHub... >> "%LOG_FILE%"
+setlocal EnableDelayedExpansion
+for %%F in (apps.json select_apps.ps1 install_apps.ps1) do (
+    set "SRC=!GITHUB_RAW_BASE!/%%F"
+    set "DST=!SCRIPTS_DIR!\\%%F"
+    echo [GitHub] Downloading %%F from !SRC! to !DST! >> "%LOG_FILE%"
+    powershell -ExecutionPolicy Bypass -NoProfile -Command "try {Invoke-WebRequest -Uri '!SRC!' -OutFile '!DST!' -UseBasicParsing; if (-Not (Test-Path -Path '!DST!')) {Exit 1}} catch {Exit 1}" >> "%LOG_FILE%" 2>&1
+    if not exist "!DST!" (
+        echo [ERROR] Failed to download %%F. Please check internet connection or repository access. >> "%LOG_FILE%"
+        set "DOWNLOAD_FAILED=1"
+    )
+)
+endlocal
+
+:CHECK_FILES
+:: Validate downloaded files exist
+if not exist "%SCRIPTS_DIR%\\select_apps.ps1" (
+    echo [ERROR] select_apps.ps1 not found after GitHub pull. See log for details. >> "%LOG_FILE%"
+    set "DOWNLOAD_FAILED=1"
+)
+if not exist "%SCRIPTS_DIR%\\install_apps.ps1" (
+    echo [ERROR] install_apps.ps1 not found after GitHub pull. See log for details. >> "%LOG_FILE%"
+    set "DOWNLOAD_FAILED=1"
+)
+if not exist "%SCRIPTS_DIR%\\apps.json" (
+    echo [ERROR] apps.json not found after GitHub pull. See log for details. >> "%LOG_FILE%"
+    set "DOWNLOAD_FAILED=1"
+)
+
+if %DOWNLOAD_FAILED% == 1 (
+    echo [FATAL] Failed to fetch required startup scripts from GitHub. >> "%LOG_FILE%"
+    echo Please check your internet connection and that the GitHub repository is publicly accessible. >> "%LOG_FILE%"
+    echo Exiting. >> "%LOG_FILE%"
+    echo. 
+    echo ERROR: Could not pull necessary startup scripts from GitHub. Please check internet connectivity and repo accessibility.
+    echo See log at %LOG_FILE% for details.
+    pause
+    goto :EOF
+)
 
 :: --- Run the GUI selection for apps to install (if available) ---
 echo Launching program selection dialog... >> "%LOG_FILE%"
-powershell.exe -ExecutionPolicy Bypass -File "C:\startupscripts\select_apps.ps1" >> "%LOG_FILE%" 2>&1
+powershell.exe -ExecutionPolicy Bypass -File "%SCRIPTS_DIR%\select_apps.ps1" >> "%LOG_FILE%" 2>&1
 
 :: If apps_selected.json exists, install those; otherwise fall back to default apps.json
 if exist "C:\startupscripts\apps_selected.json" (
     echo Using selected apps from apps_selected.json >> "%LOG_FILE%"
-    powershell.exe -ExecutionPolicy Bypass -File "C:\startupscripts\install_apps.ps1" -AppsJsonPath "C:\startupscripts\apps_selected.json" >> "%LOG_FILE%" 2>&1
+    powershell.exe -ExecutionPolicy Bypass -File "%SCRIPTS_DIR%\install_apps.ps1" -AppsJsonPath "C:\startupscripts\apps_selected.json" >> "%LOG_FILE%" 2>&1
 ) else (
     echo No selection made or selection file not found. Falling back to default apps.json >> "%LOG_FILE%"
-    powershell.exe -ExecutionPolicy Bypass -File "C:\startupscripts\install_apps.ps1" -AppsJsonPath "C:\startupscripts\apps.json" >> "%LOG_FILE%" 2>&1
+    powershell.exe -ExecutionPolicy Bypass -File "%SCRIPTS_DIR%\install_apps.ps1" -AppsJsonPath "C:\startupscripts\apps.json" >> "%LOG_FILE%" 2>&1
 )
 
 


### PR DESCRIPTION
 • Summary
  • Aligns host startup flow to pull startup scripts from the public GitHub repo cods4/windows_sandbox (main branch).
  • Includes the updated select_apps.ps1 as part of the GitHub-pull-ready changes.
 • What changed
  • startup.bat: fetches scripts from public GitHub (main)
  • select_apps.ps1: updated to align with the flow
  • install_apps.ps1: cleaned of stray '+' characters
  • agents.md: governance note about not editing startup.bat locally
 • Testing plan
  1. Run startup.bat and ensure scripts pull from GitHub.
  2. Run GUI to generate apps_selected.json.
  3. Validate winget install flow proceeds as expected.
 • Notes
  • This workflow relies on Internet access and public repo visibility. If the repo becomes private, pulling will fail and the user will see a clear error with guidance to check
  connectivity.